### PR TITLE
Use a normal print function

### DIFF
--- a/XTBox.py
+++ b/XTBox.py
@@ -12,9 +12,9 @@ try:
     from lastversion import latest
     from XTLLib import achooser, fwrite, muulter, runaspowershell, SetVars
 except:
-    printer.lprint("Fixing libraries, wait...")
+    print("Fixing libraries, wait...")
     system("pip install -U XeLib lastversion colorama psutil XTLLib")
-    printer.lprint("Libraries installed successfully!")
+    print("Libraries installed successfully!")
 
 # Some crap that can't be inside XTLLib
 def runqol(froms, choose):


### PR DESCRIPTION
Use a normal print function instead of one that depends on a 3rd party library,
It makes much more sense